### PR TITLE
command argument completion

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -859,6 +859,39 @@ Bootstrapping
 
 To ensure that such a friendly – and *relatively* high-level – project requirement as ``argcmdr`` is satisfied, consider the expressly low-level utility install-cli_, with which to guide contributors through the process of provisioning your project's most basic requirements.
 
+Shell completion
+----------------
+
+``argcmdr`` supports shell command argument completion via ``argcomplete`` (see argcomplete_).
+
+As explained by its documentation, your user may enable argument completion, either:
+
+* specifically for your shell command
+* or generally for any script containing the string **PYTHON_ARGCOMPLETE_OK** in its first 1024 bytes
+
+For flexibility, (and, *e.g.*, in support of installation into virtual environments, or otherwise where system- or user-global installation is undesirable or impossible), ``argcmdr`` *does not* currently insist on a particular scheme to enable argument completion.
+
+Rather, for example, to enable argument completion system-wide, specifically for the ``manage`` command (provisioned by ``argcmdr``), you might execute the following from a Bash shell (as the root user)::
+
+    register-python-argcomplete --shell bash manage > /etc/bash_completion.d/python-argcomplete-manage.sh
+
+Alternatively, the same argument completion may be enabled, but only for the current user::
+
+    mkdir -p ~/.bash_completion.d
+    register-python-argcomplete --shell bash manage > ~/.bash_completion.d/python-argcomplete-manage.sh
+
+Only in the latter case, the user must have the file ``~/.bash_completion``, including contents of the following form::
+
+    if [ -d ~/.bash_completion.d/ ] && [ ! -z "$(ls ~/.bash_completion.d/)" ]; then
+      for bcfile in ~/.bash_completion.d/*; do
+        . "$bcfile"
+      done
+    fi
+
+(Bash will load this file automatically.)
+
+Having so enabled argument completion (for your command), in your shell, ``argcmdr`` will handle the rest.
+
 .. _argparse: https://docs.python.org/3/library/argparse.html
 .. _python.org: https://www.python.org/downloads/
 .. _Homebrew: https://brew.sh/
@@ -867,3 +900,4 @@ To ensure that such a friendly – and *relatively* high-level – project requi
 .. _plumbum: https://plumbum.readthedocs.io/en/latest/local_commands.html#exit-codes
 .. _Dickens: https://github.com/dssg/dickens
 .. _install-cli: https://github.com/dssg/install-cli
+.. _argcomplete: https://argcomplete.readthedocs.io/

--- a/README.rst
+++ b/README.rst
@@ -890,7 +890,11 @@ Only in the latter case, the user must have the file ``~/.bash_completion``, inc
 
 (Bash will load this file automatically.)
 
-Having so enabled argument completion (for your command), in your shell, ``argcmdr`` will handle the rest.
+In the case that neither system-wide nor user-only installation is appropriate, the same argument completion may be enabled, but only for the current shell::
+
+    eval "$(register-python-argcomplete --shell bash manage)"
+
+Regardless of the method, having so enabled argument completion (for your command), in your shell, ``argcmdr`` will handle the rest, generating completion suggestions based on your command definition.
 
 .. _argparse: https://docs.python.org/3/library/argparse.html
 .. _python.org: https://www.python.org/downloads/

--- a/README.rst
+++ b/README.rst
@@ -864,7 +864,7 @@ Shell completion
 
 ``argcmdr`` supports shell command argument completion via ``argcomplete`` (see argcomplete_).
 
-As explained by its documentation, your user may enable argument completion, either:
+As explained by its documentation, your user (perhaps in executing the installation of your command), may enable argument completion, either:
 
 * specifically for your shell command
 * or generally for any script containing the string **PYTHON_ARGCOMPLETE_OK** in its first 1024 bytes

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
     package_dir={'': SRC_DIR},
     py_modules=[MODULE],
     install_requires=[
+        'argcomplete==1.9.4',
         'Dickens==1.0.1',
         'plumbum==1.6.4',
     ],

--- a/src/argcmdr.py
+++ b/src/argcmdr.py
@@ -1,3 +1,4 @@
+import argcomplete
 import argparse
 import collections
 import enum
@@ -60,6 +61,7 @@ def main(command_class,
         check_version(minimum_version)
         (parser, args) = command_class.get_parser()
         extend_parser(parser)
+        argcomplete.autocomplete(parser)
         parser.parse_args(argv, args)
         command = args.__command__
         command.call(args)


### PR DESCRIPTION
Integration with `argcomplete` to enable argument completion of any `argcmdr` command.

Due to the nature of Bash argument completion hooks, this is as much about guiding system installation as it is about enhancing the library; (and `argcomplete` almost entirely handles the latter).

I experimented with `argcomplete`'s generalized system installation scheme, wherein rather than enabling completion for any specific command, a generalized shell handler checks *every* command whose arguments the user tries to tab-complete, based on whether it can find a certain string in the script's contents. However, this scheme simply didn't work for me, and appeared to require **a lot** of work on behalf of that general handler &ndash; checking if the script was in fact generated by `setuptools` and invokes the true script in turn, or for that matter if it was generated by `pyenv` and invokes the `setuptools` script and ... *etc.*

It seemed better to leave implementation of the hook up to the package author. If you're developing a general-purpose command, (which requires `argcmdr`), perhaps your library's installer will, following the documentation I added, enable completion. Or, perhaps the end-user, (not unlikely a developer of some sort anyway), can follow these steps to enable completion, as a nice, but entirely optional, extra.

So, I left it open-ended, and just documented in brief the steps that I tested successfully, and which I would recommend, depending on the system level at which you would like to enable argument completion. I used the `manage` command as an example, since this ships with `argcmdr`, and (at least for me) is the most immediately-useful to be able to tab-complete.

One proviso, which I'll likely document in a separate, general effort, to highlight best practices &ndash; this is one case which really exposes the performance of Python-based commands, relative to other (say compiled) ones. In order for `argcomplete` to determine the interface, it must execute your command, interrupting it only once the parser has been completely defined. The delay to get to this point is really not noticeable relative to the time it takes to then actually do most anything else, that is, when you're actually executing the command. But when you're waiting on tab-completion suggestions ... that delay really stands out. I don't think there's an (easy) general solution to this, but it's another reason to underscore the best practices in using `argcmdr`, to ensure all the heavy lifting is postponed until you actually run a particular command.